### PR TITLE
Fix gateway timeout issue in recipe generator

### DIFF
--- a/recipe-generator/recipe-generator.js
+++ b/recipe-generator/recipe-generator.js
@@ -85,6 +85,9 @@ $(".dishy").click(async function() {
     }
   } catch (error) {
     console.error("Error fetching recipes:", error);
+    if (error.message === "Request timed out") {
+      alert("Request timed out. Please reload or try again.");
+    }
   }
 });
 


### PR DESCRIPTION
Fixes #1

Address frequent status 504 errors in `api/get-recipe` call.

* **Add timeout mechanism in `api/get-recipe.js`:**
  - Use `Promise.race` to add a timeout mechanism to the OpenAI API call.
  - Set the timeout duration to 30 seconds.
  - Return a 504 status code if the OpenAI API call times out.

* **Add user alert in `recipe-generator/recipe-generator.js`:**
  - Add an alert to notify the user when a 504 status code is returned.
  - Display a message to reload or try again if the request times out.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/devhrvx/Dishy/pull/2?shareId=57781657-10f4-4fd0-b2d2-2829d4bf5187).